### PR TITLE
Fix README instructions and add root overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# SomnaSync
+
+SomnaSync is an iOS sleep optimization app featuring advanced AI/ML analysis and Apple Watch integration. The full Xcode project is included in this repository as a compressed archive.
+
+## Quick Start
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/<your-github-username>/SomnaSync.git
+   cd SomnaSync
+   ```
+2. **Unzip the project files**
+   ```bash
+   unzip SomnaSync-Pro-Xcode-Complete.zip
+   cd SomnaSync-Pro-Xcode-Complete
+   ```
+3. **Open in Xcode**
+   ```bash
+   open SomnaSync.xcodeproj
+   ```
+
+For detailed setup instructions, see [README_XCODE.md](README_XCODE.md). Information about the AI/ML implementation can be found in [README_SWIFT_CONVERSION.md](README_SWIFT_CONVERSION.md).
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/README_SWIFT_CONVERSION.md
+++ b/README_SWIFT_CONVERSION.md
@@ -120,27 +120,33 @@ SomnaSync Pro ML Architecture
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/your-username/SomnaSync-Pro-Xcode-Complete.git
+   git clone https://github.com/<your-github-username>/SomnaSync.git
+   cd SomnaSync
+   ```
+
+2. **Unzip the project files**
+   ```bash
+   unzip SomnaSync-Pro-Xcode-Complete.zip
    cd SomnaSync-Pro-Xcode-Complete
    ```
 
-2. **Install Python dependencies** (for model training)
+3. **Install Python dependencies** (for model training)
    ```bash
    cd SomnaSync/ML
    pip install -r requirements.txt
    ```
 
-3. **Train the Core ML model**
+4. **Train the Core ML model**
    ```bash
    python train_sleep_model.py
    ```
 
-4. **Open in Xcode**
+5. **Open in Xcode**
    ```bash
    open SomnaSync.xcodeproj
    ```
 
-5. **Build and run**
+6. **Build and run**
    - Select your target device
    - Build the project (⌘+B)
    - Run the app (⌘+R)

--- a/README_XCODE.md
+++ b/README_XCODE.md
@@ -61,28 +61,34 @@ SomnaSync Pro is now a fully functional, production-ready iOS sleep optimization
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/yourusername/SomnaSync-Pro-Xcode-Complete.git
+   git clone https://github.com/<your-github-username>/SomnaSync.git
+   cd SomnaSync
+   ```
+
+2. **Unzip the project files**
+   ```bash
+   unzip SomnaSync-Pro-Xcode-Complete.zip
    cd SomnaSync-Pro-Xcode-Complete
    ```
 
-2. **Open in Xcode**
+3. **Open in Xcode**
    ```bash
    open SomnaSync.xcodeproj
    ```
 
-3. **Configure Bundle Identifiers**
+4. **Configure Bundle Identifiers**
    - Update bundle identifiers in project settings
    - Configure team and provisioning profiles
    - Set up Apple Developer account for HealthKit capabilities
 
-4. **Train the ML Model** (Optional)
+5. **Train the ML Model** (Optional)
    ```bash
    cd SomnaSync/ML
    python3 train_sleep_model.py
    ```
    - Copy the generated `SleepStagePredictor.mlmodel` to the ML folder in Xcode
 
-5. **Build and Run**
+6. **Build and Run**
    - Select your target device
    - Build and run the project
    - Grant necessary permissions when prompted


### PR DESCRIPTION
## Summary
- add repository-level README with quick start info
- update README_XCODE.md to use this repo path and include unzip instructions
- update README_SWIFT_CONVERSION.md similarly

## Testing
- `python3 -m py_compile train_sleep_model.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863fab6a2f88321b34137073af158a3