### PR TITLE
Update Python requirements and docs

### DIFF
--- a/README_SWIFT_CONVERSION.md
+++ b/README_SWIFT_CONVERSION.md
@@ -134,6 +134,9 @@ SomnaSync Pro ML Architecture
    ```bash
    cd SomnaSync/ML
    pip install -r requirements.txt
+   # Training uses Apple's Create ML, available only on macOS.
+   # This framework is not installed via pip; install Xcode or the
+   # Create ML tools on your Mac.
    ```
 
 4. **Train the Core ML model**

--- a/README_XCODE.md
+++ b/README_XCODE.md
@@ -85,6 +85,7 @@ SomnaSync Pro is now a fully functional, production-ready iOS sleep optimization
    ```bash
    cd SomnaSync/ML
    python3 train_sleep_model.py
+   # Requires Apple's Create ML framework (macOS only)
    ```
    - Copy the generated `SleepStagePredictor.mlmodel` to the ML folder in Xcode
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pandas>=1.5.0
 numpy>=1.21.0
-create-ml>=1.0.0
+# Apple's Create ML framework is required for training on macOS only
+# and is not available via pip.
 scikit-learn>=1.1.0
-coremltools>=6.0.0 
+coremltools>=6.0.0


### PR DESCRIPTION
## Summary
- remove unsupported `create-ml` dependency
- explain that training requires Apple's Create ML tools on macOS
- update Xcode and Swift conversion guides accordingly

## Testing
- `pytest -q`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6863feabc5248321902d48c093be3baf