### PR TITLE
Generalize numeric helper functions

### DIFF
--- a/Managers/SmartAlarmSystem.swift
+++ b/Managers/SmartAlarmSystem.swift
@@ -1207,15 +1207,15 @@ class BiometricMonitor {
         }
     }
     
-    private func calculateLinearTrend(_ values: [Double]) -> Double {
+    private func calculateLinearTrend<T: BinaryFloatingPoint>(_ values: [T]) -> Double {
         let n = Double(values.count)
-        let indices = Array(0..<values.count).map { Double($0) }
-        
+        let indices = (0..<values.count).map { Double($0) }
+
         let sumX = indices.reduce(0, +)
-        let sumY = values.reduce(0, +)
-        let sumXY = zip(indices, values).map(*).reduce(0, +)
+        let sumY = values.reduce(0) { $0 + Double($1) }
+        let sumXY = zip(indices, values).map { $0 * Double($1) }.reduce(0, +)
         let sumX2 = indices.map { $0 * $0 }.reduce(0, +)
-        
+
         let slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX)
         return slope
     }
@@ -1238,19 +1238,19 @@ class BiometricMonitor {
         return correlations
     }
     
-    private func calculateCorrelation(_ x: [Double], _ y: [Double]) -> Float {
+    private func calculateCorrelation<T: BinaryFloatingPoint>(_ x: [T], _ y: [T]) -> Float {
         guard x.count == y.count && x.count > 1 else { return 0.0 }
-        
+
         let n = Double(x.count)
-        let sumX = x.reduce(0, +)
-        let sumY = y.reduce(0, +)
-        let sumXY = zip(x, y).map(*).reduce(0, +)
-        let sumX2 = x.map { $0 * $0 }.reduce(0, +)
-        let sumY2 = y.map { $0 * $0 }.reduce(0, +)
-        
+        let sumX = x.reduce(0) { $0 + Double($1) }
+        let sumY = y.reduce(0) { $0 + Double($1) }
+        let sumXY = zip(x, y).map { Double($0) * Double($1) }.reduce(0, +)
+        let sumX2 = x.map { Double($0) * Double($0) }.reduce(0, +)
+        let sumY2 = y.map { Double($0) * Double($0) }.reduce(0, +)
+
         let numerator = n * sumXY - sumX * sumY
         let denominator = sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY))
-        
+
         return denominator != 0 ? Float(numerator / denominator) : 0.0
     }
     

--- a/Sources/HealthKit/HealthKitManagerPart5.swift
+++ b/Sources/HealthKit/HealthKitManagerPart5.swift
@@ -149,17 +149,17 @@ import os.log
         return insights
     }
     
-    private func calculateLinearTrend(_ values: [Double]) -> Double {
+    private func calculateLinearTrend<T: BinaryFloatingPoint>(_ values: [T]) -> Double {
         guard values.count > 1 else { return 0.0 }
-        
+
         let n = Double(values.count)
-        let indices = Array(0..<values.count).map { Double($0) }
-        
+        let indices = (0..<values.count).map { Double($0) }
+
         let sumX = indices.reduce(0, +)
-        let sumY = values.reduce(0, +)
-        let sumXY = zip(indices, values).map(*).reduce(0, +)
+        let sumY = values.reduce(0) { $0 + Double($1) }
+        let sumXY = zip(indices, values).map { $0 * Double($1) }.reduce(0, +)
         let sumX2 = indices.map { $0 * $0 }.reduce(0, +)
-        
+
         let slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX)
         return slope
     }

--- a/Sources/HealthKit/HealthKitManagerPart6.swift
+++ b/Sources/HealthKit/HealthKitManagerPart6.swift
@@ -20,15 +20,15 @@ import os.log
         }
     }
     
-    private func calculateLinearTrend(_ values: [Double]) -> Double {
+    private func calculateLinearTrend<T: BinaryFloatingPoint>(_ values: [T]) -> Double {
         let n = Double(values.count)
-        let indices = Array(0..<values.count).map { Double($0) }
-        
+        let indices = (0..<values.count).map { Double($0) }
+
         let sumX = indices.reduce(0, +)
-        let sumY = values.reduce(0, +)
-        let sumXY = zip(indices, values).map(*).reduce(0, +)
+        let sumY = values.reduce(0) { $0 + Double($1) }
+        let sumXY = zip(indices, values).map { $0 * Double($1) }.reduce(0, +)
         let sumX2 = indices.map { $0 * $0 }.reduce(0, +)
-        
+
         let slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX)
         return slope
     }
@@ -52,30 +52,30 @@ import os.log
         return correlations
     }
     
-    private func calculateCorrelation(_ x: [Double], _ y: [Double]) -> Float {
+    private func calculateCorrelation<T: BinaryFloatingPoint>(_ x: [T], _ y: [T]) -> Float {
         guard x.count == y.count && x.count > 1 else { return 0.0 }
-        
+
         let n = Double(x.count)
-        let sumX = x.reduce(0, +)
-        let sumY = y.reduce(0, +)
-        let sumXY = zip(x, y).map(*).reduce(0, +)
-        let sumX2 = x.map { $0 * $0 }.reduce(0, +)
-        let sumY2 = y.map { $0 * $0 }.reduce(0, +)
-        
+        let sumX = x.reduce(0) { $0 + Double($1) }
+        let sumY = y.reduce(0) { $0 + Double($1) }
+        let sumXY = zip(x, y).map { Double($0) * Double($1) }.reduce(0, +)
+        let sumX2 = x.map { Double($0) * Double($0) }.reduce(0, +)
+        let sumY2 = y.map { Double($0) * Double($0) }.reduce(0, +)
+
         let numerator = n * sumXY - sumX * sumY
         let denominator = sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY))
-        
+
         return denominator != 0 ? Float(numerator / denominator) : 0.0
     }
     
-    private func calculateStatistics(_ values: [Double]) -> (mean: Double, stdDev: Double) {
+    private func calculateStatistics<T: BinaryFloatingPoint>(_ values: [T]) -> (mean: Double, stdDev: Double) {
         guard !values.isEmpty else { return (0, 0) }
-        
-        let mean = values.reduce(0, +) / Double(values.count)
-        let squaredDifferences = values.map { pow($0 - mean, 2) }
+
+        let mean = values.reduce(0) { $0 + Double($1) } / Double(values.count)
+        let squaredDifferences = values.map { pow(Double($0) - mean, 2) }
         let variance = squaredDifferences.reduce(0, +) / Double(values.count)
         let stdDev = sqrt(variance)
-        
+
         return (mean: mean, stdDev: stdDev)
     }
 }


### PR DESCRIPTION
## Summary
- use generics in trend and correlation helpers

## Testing
- `swift tests/test_background_health_analyzer.swift`
- `swift tests/test_models.swift`
- `swift tests/test_volume_auto_change.swift` *(fails: volume bug)*

------
https://chatgpt.com/codex/tasks/task_e_686419177fdc8321bfe2b8b8b03a59a9