### PR TITLE
Agent2: iOS 26 API audit

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -126,8 +126,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             UINavigationBar.appearance().scrollEdgeAppearance = appearance
         }
         
-        // Set status bar style
-        UIApplication.shared.statusBarStyle = .lightContent
+        // Status bar style is handled by `AppHostingController`
     }
     
     private func handleDeepLink(url: URL) {

--- a/App/HostingController.swift
+++ b/App/HostingController.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+/// Custom hosting controller to manage status bar appearance in iOS 13+
+class AppHostingController<Content: View>: UIHostingController<Content> {
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+}
+

--- a/App/SceneDelegate.swift
+++ b/App/SceneDelegate.swift
@@ -11,9 +11,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Create the SwiftUI view that provides the window contents
         let contentView = ContentView()
         
-        // Use a UIHostingController as window root view controller
+        // Use a custom hosting controller to manage status bar appearance
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = UIHostingController(rootView: contentView)
+        window.rootViewController = AppHostingController(rootView: contentView)
         self.window = window
         window.makeKeyAndVisible()
         

--- a/Documentation/IOS26_AUDIT_REPORT.md
+++ b/Documentation/IOS26_AUDIT_REPORT.md
@@ -1,0 +1,20 @@
+# iOS 26 API Audit Report
+
+This report documents the results of an audit of SomnaSync's codebase for compatibility with iOS 26. The review focused on `Managers/`, `Utilities/`, and `Views/` modules.
+
+## Summary of Updates
+
+- Replaced deprecated `NavigationView` with `NavigationStack` across all SwiftUI views.
+- Implemented `AppHostingController` to manage status bar style, removing the deprecated `UIApplication.shared.statusBarStyle` usage.
+- Updated `SceneDelegate` to use the new hosting controller.
+
+## Recommendations
+
+- Review remaining UIKit-based APIs for modern SwiftUI replacements.
+- Consider adopting Swift Concurrency features (e.g., `Clock` timers) where `Timer` is still in use.
+- Investigate `UIBackgroundTaskIdentifier` usage within `AppleWatchManager` and migrate to `BGTaskScheduler` if appropriate.
+
+## Further Discussion
+
+The replacement of timers and background task handling may introduce breaking changes. An issue should be opened to coordinate these updates with the team.
+

--- a/Views/EnhancedAudioView.swift
+++ b/Views/EnhancedAudioView.swift
@@ -10,7 +10,7 @@ struct EnhancedAudioView: View {
     @State private var customLayers: [AudioLayer] = []
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 24) {
                     // MARK: - Audio Visualization
@@ -465,7 +465,7 @@ struct LayerEditorView: View {
     @State private var selectedLayerType: AudioLayerType = .binauralBeats
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 20) {
                 // Layer Type Selection
                 VStack(alignment: .leading, spacing: 8) {

--- a/Views/EnhancedSleepView.swift
+++ b/Views/EnhancedSleepView.swift
@@ -21,7 +21,7 @@ struct EnhancedSleepView: View {
     @State private var isLoading = true
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ZStack {
                 // Background
                 LinearGradient(
@@ -556,7 +556,7 @@ struct WindDownView: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 24) {
                 if windDownManager.isWindDownActive {
                     WindDownActiveView(windDownManager: windDownManager)

--- a/Views/OnboardingView.swift
+++ b/Views/OnboardingView.swift
@@ -17,7 +17,7 @@ struct OnboardingView: View {
     private let totalSteps = 4
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ZStack {
                 // Background gradient
                 LinearGradient(

--- a/Views/SleepView.swift
+++ b/Views/SleepView.swift
@@ -50,7 +50,7 @@ struct SleepView: View {
     @State private var analysisProgress: Double = 0.0
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 20) {
                     // Header with sleep score
@@ -1071,7 +1071,7 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             Form {
                 Section("Sleep Settings") {
                     Text("Sleep preferences and configuration")
@@ -1335,7 +1335,7 @@ struct AudioControlsView: View {
     @State private var ambientGenre: AmbientGenre = .atmospheric
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 24) {
                     // Pre-Sleep Audio Section
@@ -1931,7 +1931,7 @@ struct AudioSettingsView: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             Form {
                 Section("Audio Quality") {
                     Toggle("Spatial Audio", isOn: $audioEngine.spatialAudioEnabled)
@@ -2460,7 +2460,7 @@ struct SleepSessionView: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack {
                 Text("Sleep Session View")
                     .font(.title)
@@ -2486,7 +2486,7 @@ struct AppleWatchSetupView: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack {
                 Text("Apple Watch Setup")
                     .font(.title)


### PR DESCRIPTION
## Summary
- replace deprecated `NavigationView` with `NavigationStack`
- create `AppHostingController` to manage status bar style
- use the hosting controller in `SceneDelegate`
- remove deprecated status bar API usage
- document the audit in `Documentation/IOS26_AUDIT_REPORT.md`

## Testing
- `swift tests/test_background_health_analyzer.swift`
- `swift tests/test_volume_auto_change.swift`
- `swift tests/test_models.swift`


------
https://chatgpt.com/codex/tasks/task_e_68641c385f0c8321bb32d3741c29ff4c