### PR TITLE
Add edge case tests and coverage report

### DIFF
--- a/Documentation/TEST_COVERAGE_REPORT.md
+++ b/Documentation/TEST_COVERAGE_REPORT.md
@@ -1,0 +1,18 @@
+# 📊 Test Coverage Report
+
+This report summarizes the current unit test coverage for SomnaSync.
+
+## Covered Modules
+- **Analytics** – `test_background_health_analyzer.swift` exercises anomaly counting and model accuracy helpers.
+- **Managers** – `test_watch_sync_start_stop.swift` verifies watch sync services.
+- **Models** – `test_models.swift` validates `SleepSession` duration, `SleepStage` helpers and audio type names.
+- **Utilities** – `test_volume_auto_change.swift` tests volume updates in a mock engine.
+- **Audio Generation Engine** – `test_audio_generation.swift` covers sine wave, noise generation, volume scaling and fade logic.
+
+## Coverage Gaps
+- **ML Prediction Engine** – no direct tests for `SleepStagePredictor` due to framework dependencies.
+- **View Layer** – views and UI components lack tests.
+- **Apple Watch Managers** – advanced watch integration paths are untested.
+- **App delegate and configuration** – initialization routines are not covered.
+
+Additional unit tests should be added for these areas when environment and tooling allow.

--- a/tests/test_audio_generation.swift
+++ b/tests/test_audio_generation.swift
@@ -57,4 +57,25 @@ let faded = applyFade(fadeInput, fadeInDuration: 1.0, fadeOutDuration: 1.0, samp
 assert(abs(faded.first ?? 1 - 0) < 0.0001)
 assert(abs(faded.last ?? 1 - 0) < 0.0001)
 
+// Edge cases
+let zeroDuration = generateSineWave(frequency: 440.0, duration: 0.0, sampleRate: 4.0)
+assert(zeroDuration.isEmpty)
+
+let zeroFrequency = generateSineWave(frequency: 0.0, duration: 1.0, sampleRate: 4.0)
+for sample in zeroFrequency { assert(abs(sample) < 0.0001) }
+
+let zeroNoise = generateNoise(frameCount: 0, scale: 1.0)
+assert(zeroNoise.isEmpty)
+
+let negativeVolume = applyVolume([1.0], volume: -0.5)
+assert(negativeVolume == [-0.5])
+
+let highVolume = applyVolume([1.0], volume: 1.5)
+assert(highVolume == [1.5])
+
+let shortFade = applyFade([1, 1], fadeInDuration: 3.0, fadeOutDuration: 3.0, sampleRate: 1.0)
+assert(shortFade.count == 2)
+assert(abs(shortFade.first ?? 1 - 0) < 0.0001)
+assert(abs(shortFade.last ?? 1 - 0) < 0.0001)
+
 print("All audio generation tests passed")

--- a/tests/test_models.swift
+++ b/tests/test_models.swift
@@ -79,4 +79,18 @@ assert(audio1.displayName == "Binaural Beats (6Hz)")
 let audio2 = PreSleepAudioType.whiteNoise(color: .white)
 assert(audio2.displayName == "White Noise")
 
+// Edge cases
+let incompleteSession = SleepSession(startTime: start, endTime: nil, sleepStage: .awake, quality: 0.0, cycleCount: 0)
+assert(incompleteSession.duration == 0)
+
+let zeroFreqAudio = PreSleepAudioType.binauralBeats(frequency: 0.0)
+assert(zeroFreqAudio.displayName == "Binaural Beats (0Hz)")
+
+func normalizeHeartRate(_ hr: Double) -> Double {
+    return max(0, min(1, (hr - 40) / 60))
+}
+
+assert(normalizeHeartRate(30) == 0)
+assert(normalizeHeartRate(100) == 1)
+
 print("All tests passed")

--- a/tests/test_volume_auto_change.swift
+++ b/tests/test_volume_auto_change.swift
@@ -26,4 +26,25 @@ if engine.volume != 0.8 {
     print("Test failed: volume did not update correctly when auto-change mode is enabled")
     exit(1)
 }
+// Additional edge cases
+engine.setVolume(0.3, immediate: false)
+if engine.volume != 0.3 {
+    print("Test failed: volume should update on delayed change")
+    exit(1)
+}
+
+engine.autoChangeEnabled = false
+engine.setVolume(1.0, immediate: true)
+if engine.volume != 1.0 {
+    print("Test failed: volume should update when auto-change disabled")
+    exit(1)
+}
+
+let sameVolume = engine.volume
+engine.setVolume(sameVolume, immediate: true)
+if engine.volume != sameVolume {
+    print("Test failed: volume changed unexpectedly")
+    exit(1)
+}
+
 print("Test passed")


### PR DESCRIPTION
## Summary
- extend audio generation tests with additional edge cases
- cover volume change edge scenarios
- expand models tests to validate edge cases
- document current test coverage in `TEST_COVERAGE_REPORT.md`

## Testing
- `swift tests/test_audio_generation.swift`
- `swift tests/test_volume_auto_change.swift`
- `swift tests/test_background_health_analyzer.swift`
- `swift tests/test_watch_sync_start_stop.swift`
- `swift tests/test_models.swift`


------
https://chatgpt.com/codex/tasks/task_e_68641c57e9288321b13a1252e013b6c1